### PR TITLE
fix(Workflows): tj-actions fallout

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,11 +22,11 @@ jobs:
       charts: ${{ steps.charts.outputs.charts }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Get Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: JJGadgets/tj-actions-changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
         with:
           files: charts/**/metadata.yaml
 
@@ -52,15 +52,15 @@ jobs:
       fail-fast: false
     steps:
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
 
       - name: Install Cosign
         if: ${{ github.event_name != 'pull_request' }}
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3
 
       - name: Login to GitHub Container Registry
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -15,7 +15,7 @@
       "description": ["Process Chart versions"],
       "fileMatch": ["(^|/)metadata\\.ya?ml$"],
       "matchStrings": ["registry: (?<registryUrl>\\S+)\nchart: (?<depName>\\S+)\nversion: (?<currentValue>\\S+)"],
-      "datasourceTemplate": "helm",
+      "datasourceTemplate": "helm"
     }
   ],
   "packageRules": [
@@ -30,10 +30,10 @@
     {
       "description": ["Auto-merge GitHub Actions"],
       "matchManagers": ["github-actions"],
-      "matchDatasources": ["github-tags"],
       "automerge": true,
       "automergeType": "branch",
       "matchUpdateTypes": ["minor", "patch", "digest"],
+      "minimumReleaseAge": "3 days",
       "ignoreTests": true
     },
     {


### PR DESCRIPTION
1. Add digests to actions, similar to home-ops 
2. Remove comma from last item
2. Add Min time for auto pulling GHA in renovate config

I am assuming this is the way this should be done, using digests and `minimumReleaseAge`, but maybe we don't need digests with `minimumReleaseAge`? 

Either way, feel free to make edits to this PR, ask me to change something etc. Just trying to get this kicked off. 